### PR TITLE
Fix registration not triggered

### DIFF
--- a/js/register.js
+++ b/js/register.js
@@ -58,7 +58,7 @@ $(document).ready(function() {
         $.ajax({
             url: 'register.php',
             type: 'POST',
-            data: $(this).serialize(),
+            data: $(this).serialize() + '&register=1',
             dataType: 'json',
             success: function(result) {
                 $('#errorMessages').empty();

--- a/register.php
+++ b/register.php
@@ -26,7 +26,7 @@ $successMessage = '';
 $errors = [];
 
 // Проверка, была ли отправлена форма
-if (isset($_POST['register'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = trim($_POST['reg_username'] ?? '');
     $password = trim($_POST['reg_password'] ?? '');
     $password2 = trim($_POST['reg_password2'] ?? '');


### PR DESCRIPTION
## Summary
- ensure register.js sends the `register` parameter
- trigger registration logic in register.php on POST requests

## Testing
- `php -l register.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854a5e1c7ec832bb16555ea6cf5970c