### PR TITLE
Add basic site pages and navigation

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,0 +1,6 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Личный кабинет</h2>
+<p>Раздел в разработке.</p>
+<?php include 'templates/footer.php'; ?>

--- a/contact.php
+++ b/contact.php
@@ -1,0 +1,14 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Форма обратной связи</h2>
+<form action="#" method="post">
+    <label for="contact_name">Имя:</label>
+    <input type="text" id="contact_name" name="contact_name">
+    <label for="contact_email">Email:</label>
+    <input type="email" id="contact_email" name="contact_email">
+    <label for="contact_message">Сообщение:</label>
+    <textarea id="contact_message" name="contact_message"></textarea>
+    <input type="submit" value="Отправить">
+</form>
+<?php include 'templates/footer.php'; ?>

--- a/download.php
+++ b/download.php
@@ -1,0 +1,6 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Скачать</h2>
+<p><a href="#">Скачать игру</a></p>
+<?php include 'templates/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,78 +1,35 @@
 <?php
-require_once 'includes/config.php';
+include 'templates/header.php';
 ?>
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Добро пожаловать на <?php echo htmlspecialchars($config['servername']); ?></title>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <style>
-        .modal {
-            display: none;
-            position: fixed;
-            z-index: 1;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-            overflow: auto;
-            background-color: rgba(0,0,0,0.5);
-        }
-        .modal-content {
-            background-color: #fefefe;
-            margin: 10% auto;
-            padding: 20px;
-            border: 1px solid #888;
-            width: 80%;
-            max-width: 600px;
-            position: relative;
-        }
-        .close {
-            color: #aaa;
-            position: absolute;
-            top: 10px;
-            right: 15px;
-            font-size: 28px;
-            font-weight: bold;
-            cursor: pointer;
-        }
-    </style>
-</head>
-<body>
-    <h1>Добро пожаловать на <?php echo htmlspecialchars($config['servername']); ?></h1>
-    <p><?php echo htmlspecialchars($config['slogan']); ?></p>
-    <a href="#" id="registerLink">Регистрация</a>
+<p><?php echo htmlspecialchars($config['slogan']); ?></p>
+<a href="#" id="registerLink">Регистрация</a>
 
-    <div id="registrationModal" class="modal">
-        <div class="modal-content">
-            <span class="close" id="modalClose">&times;</span>
-            <div id="registrationContainer"></div>
-        </div>
+<div id="registrationModal" class="modal">
+    <div class="modal-content">
+        <span class="close" id="modalClose">&times;</span>
+        <div id="registrationContainer"></div>
     </div>
+</div>
 
-    <script>
-        $(document).ready(function(){
-            $('#registerLink').on('click', function(e){
-                e.preventDefault();
-                $('#registrationModal').show();
-                $('#registrationContainer').load('templates/register.html', function(){
-                    $.getScript('js/register.js');
-                });
-            });
-
-            $('#modalClose').on('click', function(){
-                $('#registrationModal').hide();
-            });
-
-            // Закрытие модального окна при клике вне него
-            $(window).on('click', function(event){
-                if (event.target === document.getElementById('registrationModal')) {
-                    $('#registrationModal').hide();
-                }
-            });
+<script>
+$(document).ready(function(){
+    $('#registerLink').on('click', function(e){
+        e.preventDefault();
+        $('#registrationModal').show();
+        $('#registrationContainer').load('templates/register.html', function(){
+            $.getScript('js/register.js');
         });
-    </script>
-</body>
-</html>
+    });
+
+    $('#modalClose').on('click', function(){
+        $('#registrationModal').hide();
+    });
+
+    $(window).on('click', function(event){
+        if (event.target === document.getElementById('registrationModal')) {
+            $('#registrationModal').hide();
+        }
+    });
+});
+</script>
+<?php include 'templates/footer.php'; ?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,12 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Вход</h2>
+<form action="#" method="post">
+    <label for="login_username">Имя:</label>
+    <input type="text" id="login_username" name="login_username">
+    <label for="login_password">Пароль:</label>
+    <input type="password" id="login_password" name="login_password">
+    <input type="submit" value="Войти">
+</form>
+<?php include 'templates/footer.php'; ?>

--- a/news.php
+++ b/news.php
@@ -1,0 +1,9 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Новости</h2>
+<article>
+    <h3>Добро пожаловать!</h3>
+    <p>Это первая новость на сайте.</p>
+</article>
+<?php include 'templates/footer.php'; ?>

--- a/store.php
+++ b/store.php
@@ -1,0 +1,6 @@
+<?php
+include 'templates/header.php';
+?>
+<h2>Магазин</h2>
+<p>Раздел в разработке.</p>
+<?php include 'templates/footer.php'; ?>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer>
+    <p>&copy; <?php echo date('Y'); ?> <?php echo htmlspecialchars($config['servername']); ?></p>
+</footer>
+</body>
+</html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../includes/config.php';
+?>
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($config['servername']); ?></title>
+    <link rel="stylesheet" href="templates/style.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+<header>
+    <h1><?php echo htmlspecialchars($config['servername']); ?></h1>
+    <nav>
+        <a href="index.php">Главная</a>
+        <a href="news.php">Новости</a>
+        <a href="login.php">Вход</a>
+        <a href="account.php">Личный кабинет</a>
+        <a href="download.php">Скачать</a>
+        <a href="contact.php">Форма</a>
+        <a href="store.php">Магазин</a>
+    </nav>
+</header>
+<main>

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,0 +1,58 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #111;
+    color: #fff;
+}
+header {
+    background: #222;
+    padding: 10px;
+}
+header h1 {
+    margin: 0 0 10px 0;
+}
+nav a {
+    color: #d4af37;
+    margin-right: 10px;
+    text-decoration: none;
+}
+main {
+    padding: 20px;
+}
+footer {
+    background: #222;
+    color: #ccc;
+    text-align: center;
+    padding: 10px;
+}
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.5);
+}
+.modal-content {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    margin: 10% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 600px;
+    position: relative;
+}
+.close {
+    color: #aaa;
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add header and footer templates with navigation
- add new pages (news, login, account, download, contact, store)
- centralize styles in `style.css` and darken modal background
- update index to use new layout

## Testing
- `php -l index.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_6854a723c61c832ba0c5e220c6ae82fa