### PR TITLE
Implement account management page

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,6 +1,90 @@
 <?php
+require_once 'includes/config.php';
+require_once 'includes/functions.php';
+
+session_start();
+
+if (!isUserLoggedIn()) {
+    header('Location: login.php');
+    exit;
+}
+
+$username = $_SESSION['user'];
+$account = getAccountInfo($username);
+$errors = [];
+$success = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'changepw') {
+        $current = trim($_POST['current_password'] ?? '');
+        $new = trim($_POST['new_password'] ?? '');
+        $confirm = trim($_POST['confirm_password'] ?? '');
+
+        if ($current === '' || $new === '' || $confirm === '') {
+            $errors[] = 'Заполните все поля для смены пароля.';
+        } elseif ($new !== $confirm) {
+            $errors[] = 'Новые пароли не совпадают.';
+        } elseif (!loginUser($username, $current)) {
+            $errors[] = 'Текущий пароль введен неверно.';
+        } else {
+            $validation = validPassword($new);
+            if ($validation !== true) {
+                $errors[] = $validation;
+            } elseif (updateAccountPassword($username, $new)) {
+                $success = 'Пароль успешно изменен.';
+            } else {
+                $errors[] = 'Не удалось изменить пароль.';
+            }
+        }
+    } elseif ($action === 'changemail') {
+        $newEmail = trim($_POST['new_email'] ?? '');
+        if ($newEmail === '') {
+            $errors[] = 'Введите новый email.';
+        } elseif (!validEMail($newEmail)) {
+            $errors[] = 'Недействительный email.';
+        } elseif (updateAccountEmail($username, $newEmail)) {
+            $success = 'Email успешно обновлен.';
+            $account['email'] = $newEmail;
+        } else {
+            $errors[] = 'Не удалось обновить email.';
+        }
+    }
+}
+
 include 'templates/header.php';
 ?>
 <h2>Личный кабинет</h2>
-<p>Раздел в разработке.</p>
+<?php if ($success): ?>
+<div class="success"><?php echo htmlspecialchars($success); ?></div>
+<?php endif; ?>
+<?php if (!empty($errors)): ?>
+<div class="error">
+    <?php foreach ($errors as $error): ?>
+        <p><?php echo htmlspecialchars($error); ?></p>
+    <?php endforeach; ?>
+</div>
+<?php endif; ?>
+<p>Имя пользователя: <?php echo htmlspecialchars($username); ?></p>
+<p>Email: <?php echo htmlspecialchars($account['email'] ?? ''); ?></p>
+
+<h3>Смена пароля</h3>
+<form action="account.php" method="post">
+    <input type="hidden" name="action" value="changepw">
+    <label>Текущий пароль:</label>
+    <input type="password" name="current_password">
+    <label>Новый пароль:</label>
+    <input type="password" name="new_password">
+    <label>Повторите новый пароль:</label>
+    <input type="password" name="confirm_password">
+    <input type="submit" value="Сменить пароль">
+</form>
+
+<h3>Смена email</h3>
+<form action="account.php" method="post">
+    <input type="hidden" name="action" value="changemail">
+    <label>Новый email:</label>
+    <input type="email" name="new_email" value="<?php echo htmlspecialchars($account['email'] ?? ''); ?>">
+    <input type="submit" value="Изменить email">
+</form>
 <?php include 'templates/footer.php'; ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -244,4 +244,40 @@ function loginUser($username, $password) {
 
     return false;
 }
+
+function isUserLoggedIn() {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+    return isset($_SESSION['user']);
+}
+
+function getAccountInfo($username) {
+    $query = doQuery('SELECT * FROM ' . TABLE_ACCOUNT_LOGIN . ' WHERE name = '\'' . addslashes_mssql($username) . '\'', DATABASE_ACCOUNT);
+    if ($query !== false) {
+        return $query->fetch(PDO::FETCH_ASSOC);
+    }
+    return false;
+}
+
+function updateAccountEmail($username, $email) {
+    $query = doQuery('UPDATE ' . TABLE_ACCOUNT_LOGIN . " SET email = '" . addslashes_mssql($email) . "' WHERE name = '" . addslashes_mssql($username) . "'", DATABASE_ACCOUNT);
+    return $query !== false;
+}
+
+function updateAccountPassword($username, $password) {
+    $hash = strtoupper(md5($password));
+    $query = doQuery('UPDATE ' . TABLE_ACCOUNT_LOGIN . " SET password = '" . $hash . "', originalpassword = '" . addslashes_mssql($password) . "' WHERE name = '" . addslashes_mssql($username) . "'", DATABASE_ACCOUNT);
+    return $query !== false;
+}
+
+function isBanned($username) {
+    $query = doQuery('SELECT ban FROM ' . TABLE_ACCOUNT_LOGIN . ' WHERE name = '\'' . addslashes_mssql($username) . '\'', DATABASE_ACCOUNT);
+    if ($query !== false) {
+        $row = $query->fetch(PDO::FETCH_ASSOC);
+        return $row && (int)$row['ban'] > 0;
+    }
+    return false;
+}
+
 ?>


### PR DESCRIPTION
## Summary
- add basic account page with password and email change forms
- provide helper functions for account info and updates

## Testing
- `php -l account.php` *(fails: command not found)*
- `php -l includes/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854ace6bbd0832ba928db5a3fa9ace4