### PR TITLE
Implement logout option and fix character fetch

### DIFF
--- a/account.php
+++ b/account.php
@@ -56,6 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 include 'templates/header.php';
 ?>
 <h2>Личный кабинет</h2>
+<p><a href="logout.php">Выйти</a></p>
 <?php if ($success): ?>
 <div class="success"><?php echo htmlspecialchars($success); ?></div>
 <?php endif; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,13 @@
+<?php
+require_once 'includes/config.php';
+require_once 'includes/functions.php';
+
+session_start();
+if (isUserLoggedIn()) {
+    $username = $_SESSION['user'];
+    logoutUser($username);
+}
+
+header('Location: index.php');
+exit;
+?>

--- a/templates/header.php
+++ b/templates/header.php
@@ -25,8 +25,15 @@ require_once __DIR__ . '/../includes/functions.php';
     <a href="#">База Знаний</a>
     <a href="#">Расписание локаций</a>
     <a href="#">Об игре</a>
-    <?php if (isUserLoggedIn() && isAdmin($_SESSION['user'])): ?>
-    <a href="admin.php">Админка</a>
+    <?php if (isUserLoggedIn()): ?>
+        <a href="account.php">Личный кабинет</a>
+        <?php if (isAdmin($_SESSION['user'])): ?>
+            <a href="admin.php">Админка</a>
+        <?php endif; ?>
+        <a href="logout.php">Выход</a>
+    <?php else: ?>
+        <a href="login.php">Вход</a>
+        <a href="register.php">Регистрация</a>
     <?php endif; ?>
 </nav>
 <header>


### PR DESCRIPTION
## Summary
- update navigation to show account, login, and logout links
- add logout link on the account page
- update `getAccountCharacters` to use `cha_ids`
- add logout helper and page

## Testing
- `php -l includes/functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854b8b4ce40832bbe441c46337c3e81