### PR TITLE
Improve layout and texts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -114,6 +114,7 @@ footer {
     display: flex;
     gap: 20px;
     justify-content: center;
+    align-items: flex-start;
 }
 
 .sidebar {
@@ -158,6 +159,15 @@ footer {
     margin-bottom: 20px;
 }
 
+.news-block {
+    background: rgba(0, 0, 0, 0.5);
+    border: 2px solid #ffcc00;
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    margin-bottom: 20px;
+}
+
 .stats ul,
 .character-stats ul {
     list-style: none;
@@ -171,13 +181,14 @@ footer {
 
 .login-box form input[type="text"],
 .login-box form input[type="password"] {
-    width: 100%;
+    width: 80%;
     padding: 8px;
-    margin-bottom: 10px;
+    margin: 0 auto 10px auto;
     border: 1px solid #ffcc00;
     border-radius: 5px;
     background: rgba(255, 255, 255, 0.1);
     color: #fff;
+    display: block;
 }
 
 .login-box input[type="submit"],

--- a/includes/config.php
+++ b/includes/config.php
@@ -3,7 +3,7 @@
 $config = array();
 
 // Общие настройки сайта
-$config['servername'] = 'Your Private Server'; // Название вашего сервера
+$config['servername'] = 'New Era server'; // Название вашего сервера
 $config['slogan'] = 'Slogan'; // Слоган
 $config['disable_registration'] = false; // Отключение регистрации
 $config['allow_dupe_email'] = false; // Разрешение дублирования email

--- a/index.php
+++ b/index.php
@@ -21,16 +21,16 @@ include 'templates/header.php';
     <div class="main-content">
         <div class="logo">New Era</div>
         <div class="slider">Здесь будет слайдер с подземельями и сокровищами</div>
-        <h3>Игровые новости</h3>
-        <p><?php echo htmlspecialchars($config['slogan']); ?></p>
-        <?php
-        $newsFile = __DIR__ . '/data/news.html';
-        if (file_exists($newsFile)) {
-            include $newsFile;
-        } else {
-            echo '<p>Новости еще не опубликованы.</p>';
-        }
-        ?>
+        <div class="news-block">
+            <?php
+            $newsFile = __DIR__ . '/data/news.html';
+            if (file_exists($newsFile)) {
+                include $newsFile;
+            } else {
+                echo '<p>Новости еще не опубликованы.</p>';
+            }
+            ?>
+        </div>
     </div>
 
     <aside class="sidebar right">


### PR DESCRIPTION
## Summary
- tweak layout so sidebars don't stretch and login inputs are narrower
- style news block to match site theme
- remove slogan and news heading
- update server name

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854c3171e6c832bb1c7d3a098d5db33