### PR TITLE
Add interactive news slider and editor

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -196,6 +196,7 @@ footer {
 .news-nav a.tab-updates { background: #5cb85c; }
 .news-nav a.tab-events { background: #5bc0de; }
 .news-nav a.tab-other { background: #9370db; }
+.news-nav a.tab-admin { background: #444; }
 
 .news-list {
     list-style: none;
@@ -238,6 +239,30 @@ footer {
     color: #555;
     margin-left: 10px;
 }
+
+.news-slider {
+    position: relative;
+    overflow: hidden;
+}
+
+.news-controls {
+    text-align: center;
+    margin-top: 10px;
+}
+
+.news-controls button {
+    background: #ffcc00;
+    color: #000;
+    border: none;
+    padding: 4px 8px;
+    margin: 0 4px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.news-item { display: none; }
+.news-item.active { display: flex; }
 
 .stats ul,
 .character-stats ul {

--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -1,0 +1,5 @@
+$(function(){
+    $('#toolbar button').on('click', function(){
+        document.execCommand($(this).data('cmd'), false, null);
+    });
+});

--- a/assets/js/news.js
+++ b/assets/js/news.js
@@ -1,0 +1,47 @@
+$(function(){
+    var allItems = $('.news-item');
+    var currentList = allItems;
+    var index = 0;
+
+    function showCurrent() {
+        allItems.hide().removeClass('active');
+        if (currentList.length) {
+            currentList.eq(index).show().addClass('active');
+        }
+    }
+
+    function setList(list) {
+        currentList = list;
+        index = 0;
+        showCurrent();
+    }
+
+    $('.news-next').on('click', function(e){
+        e.preventDefault();
+        if (!currentList.length) return;
+        index = (index + 1) % currentList.length;
+        showCurrent();
+    });
+
+    $('.news-prev').on('click', function(e){
+        e.preventDefault();
+        if (!currentList.length) return;
+        index = (index - 1 + currentList.length) % currentList.length;
+        showCurrent();
+    });
+
+    $('.news-nav a').on('click', function(e){
+        e.preventDefault();
+        $('.news-nav a').removeClass('active');
+        $(this).addClass('active');
+        var filter = $(this).data('filter');
+        if (filter === 'all') {
+            setList(allItems);
+        } else {
+            var filtered = allItems.filter('[data-category="'+filter+'"],[data-author="'+filter+'"]');
+            setList(filtered);
+        }
+    });
+
+    setList(allItems);
+});

--- a/data/news.html
+++ b/data/news.html
@@ -1,33 +1,40 @@
 <div class="news-header">
     <h2>Игровые Новости</h2>
     <nav class="news-nav">
-        <a href="#" class="active">Все новости</a>
-        <a href="#" class="tab-important">Важное</a>
-        <a href="#" class="tab-updates">Обновления</a>
-        <a href="#" class="tab-events">События</a>
-        <a href="#" class="tab-other">Другое</a>
+        <a href="#" class="active" data-filter="all">Все новости</a>
+        <a href="#" class="tab-important" data-filter="important">Важное</a>
+        <a href="#" class="tab-updates" data-filter="updates">Обновления</a>
+        <a href="#" class="tab-events" data-filter="events">События</a>
+        <a href="#" class="tab-other" data-filter="other">Другое</a>
+        <a href="#" class="tab-admin" data-filter="admin">Админ</a>
     </nav>
 </div>
 
-<ul class="news-list">
-    <li class="news-item">
-        <span class="news-category important">Важное</span>
-        <span class="news-title">Запуск сервера 1 июня!</span>
-        <span class="news-date">15.05.2024 12:00</span>
-    </li>
-    <li class="news-item">
-        <span class="news-category updates">Обновления</span>
-        <span class="news-title">Патч 1.1: новые классы и зоны</span>
-        <span class="news-date">20.05.2024 17:30</span>
-    </li>
-    <li class="news-item">
-        <span class="news-category events">События</span>
-        <span class="news-title">Турнир гильдий состоится 10 июня</span>
-        <span class="news-date">18.05.2024 18:00</span>
-    </li>
-    <li class="news-item">
-        <span class="news-category other">Другое</span>
-        <span class="news-title">Не забудьте присоединиться к нашему Discord</span>
-        <span class="news-date">19.05.2024 14:00</span>
-    </li>
-</ul>
+<div class="news-slider">
+    <ul class="news-list">
+        <li class="news-item" data-category="important" data-author="admin">
+            <span class="news-category important">Важное</span>
+            <span class="news-title">Запуск сервера 1 июня!</span>
+            <span class="news-date">15.05.2024 12:00</span>
+        </li>
+        <li class="news-item" data-category="updates" data-author="admin">
+            <span class="news-category updates">Обновления</span>
+            <span class="news-title">Патч 1.1: новые классы и зоны</span>
+            <span class="news-date">20.05.2024 17:30</span>
+        </li>
+        <li class="news-item" data-category="events" data-author="gm">
+            <span class="news-category events">События</span>
+            <span class="news-title">Турнир гильдий состоится 10 июня</span>
+            <span class="news-date">18.05.2024 18:00</span>
+        </li>
+        <li class="news-item" data-category="other" data-author="gm">
+            <span class="news-category other">Другое</span>
+            <span class="news-title">Не забудьте присоединиться к нашему Discord</span>
+            <span class="news-date">19.05.2024 14:00</span>
+        </li>
+    </ul>
+    <div class="news-controls">
+        <button class="news-prev">&#8249;</button>
+        <button class="news-next">&#8250;</button>
+    </div>
+</div>

--- a/edit_news.php
+++ b/edit_news.php
@@ -38,8 +38,18 @@ include 'templates/header.php';
 <?php if ($success): ?>
     <div class="success"><?php echo htmlspecialchars($success); ?></div>
 <?php endif; ?>
-<form action="edit_news.php" method="post">
-    <textarea name="content" rows="10" cols="80"><?php echo htmlspecialchars($content); ?></textarea><br>
+<form action="edit_news.php" method="post" onsubmit="document.getElementById('content').value=document.getElementById('editor').innerHTML;">
+    <div id="toolbar">
+        <button type="button" data-cmd="bold"><b>B</b></button>
+        <button type="button" data-cmd="italic"><i>I</i></button>
+        <button type="button" data-cmd="underline"><u>U</u></button>
+    </div>
+    <div id="editor" contenteditable="true" style="border:1px solid #ccc;min-height:200px;padding:5px;">
+        <?php echo $content; ?>
+    </div>
+    <input type="hidden" name="content" id="content">
+    <br>
     <input type="submit" value="Сохранить">
 </form>
+<script src="assets/js/editor.js"></script>
 <?php include 'templates/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -26,6 +26,7 @@ include 'templates/header.php';
             $newsFile = __DIR__ . '/data/news.html';
             if (file_exists($newsFile)) {
                 include $newsFile;
+                echo '<script src="assets/js/news.js"></script>';
             } else {
                 echo '<p>Новости еще не опубликованы.</p>';
             }

--- a/news.php
+++ b/news.php
@@ -5,6 +5,7 @@ $newsFile = __DIR__ . '/data/news.html';
 
 if (file_exists($newsFile)) {
     readfile($newsFile);
+    echo '<script src="assets/js/news.js"></script>';
 } else {
     echo '<h2>Новости</h2><p>Файл новостей не найден.</p>';
 }


### PR DESCRIPTION
## Summary
- enhance **news.html** with category tabs, admin filter and slider controls
- add jQuery logic for news slider and filtering
- style slider controls and new tab
- upgrade admin news editor with simple formatting toolbar
- load news slider script on index and news pages

## Testing
- `php` not available, could not run syntax check


------
https://chatgpt.com/codex/tasks/task_b_6854cb5227a4832ba9248408747a9c31