### PR TITLE
Improve news tab and visuals

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,8 @@ body {
     padding: 0;
     background: linear-gradient(to bottom, #1b2c41 0%, #265075 100%);
     color: #fff;
-    animation: fadeInBody 1s ease-in;
+    /* faster page transition */
+    animation: fadeInBody 0.3s ease-in;
 }
 
 @keyframes fadeInBody {
@@ -261,8 +262,6 @@ footer {
     font-weight: bold;
 }
 
-.news-item { display: none; }
-.news-item.active { display: flex; }
 
 .stats ul,
 .character-stats ul {
@@ -332,4 +331,12 @@ table.ranking td {
 
 table.ranking th {
     background: #333;
+}
+
+/* small image displayed on each page */
+.pirate-img {
+    width: 80px;
+    height: auto;
+    display: block;
+    margin: 10px auto 0 auto;
 }

--- a/assets/img/anime-pirate.svg
+++ b/assets/img/anime-pirate.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#87ceeb"/>
+  <circle cx="50" cy="50" r="30" fill="#ffe0bd" stroke="#000" stroke-width="2"/>
+  <path d="M20 40 Q50 10 80 40" fill="#000"/>
+  <rect x="45" y="40" width="20" height="10" fill="#000"/>
+  <circle cx="40" cy="50" r="5" fill="#000"/>
+  <circle cx="65" cy="50" r="5" fill="#fff" stroke="#000" stroke-width="2"/>
+  <path d="M37 65 Q50 75 63 65" stroke="#000" stroke-width="3" fill="none"/>
+</svg>

--- a/assets/js/news.js
+++ b/assets/js/news.js
@@ -2,17 +2,28 @@ $(function(){
     var allItems = $('.news-item');
     var currentList = allItems;
     var index = 0;
+    var showAll = true;
+    var controls = $('.news-controls');
 
     function showCurrent() {
         allItems.hide().removeClass('active');
-        if (currentList.length) {
+        if (!currentList.length) return;
+
+        if (showAll) {
+            currentList.show().addClass('active');
+        } else {
             currentList.eq(index).show().addClass('active');
         }
     }
-
-    function setList(list) {
+    function setList(list, all) {
         currentList = list;
         index = 0;
+        showAll = all;
+        if (showAll) {
+            controls.hide();
+        } else {
+            controls.show();
+        }
         showCurrent();
     }
 
@@ -36,12 +47,12 @@ $(function(){
         $(this).addClass('active');
         var filter = $(this).data('filter');
         if (filter === 'all') {
-            setList(allItems);
+            setList(allItems, true);
         } else {
             var filtered = allItems.filter('[data-category="'+filter+'"],[data-author="'+filter+'"]');
-            setList(filtered);
+            setList(filtered, false);
         }
     });
 
-    setList(allItems);
+    setList(allItems, true);
 });

--- a/templates/header.php
+++ b/templates/header.php
@@ -38,5 +38,6 @@ require_once __DIR__ . '/../includes/functions.php';
 </nav>
 <header>
     <h1><?php echo htmlspecialchars($config['servername']); ?></h1>
+    <img class="pirate-img" src="assets/img/anime-pirate.svg" alt="Anime Pirate">
 </header>
 <main>


### PR DESCRIPTION
## Summary
- speed up page fade-in animation
- show all news items at once when viewing **Все новости**
- hide slider controls when showing all news
- add anime pirate image to every page

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685b128e6a20832b9c5f6b82df69b8f1