### PR TITLE
Add styled-form class for consistent forms

### DIFF
--- a/account.php
+++ b/account.php
@@ -79,7 +79,7 @@ include 'templates/header.php';
 <button>Пополнить баланс</button>
 
 <h3>Смена пароля</h3>
-<form action="account.php" method="post">
+<form class="styled-form" action="account.php" method="post">
     <input type="hidden" name="action" value="changepw">
     <label>Текущий пароль:</label>
     <input type="password" name="current_password">
@@ -91,7 +91,7 @@ include 'templates/header.php';
 </form>
 
 <h3>Смена email</h3>
-<form action="account.php" method="post">
+<form class="styled-form" action="account.php" method="post">
     <input type="hidden" name="action" value="changemail">
     <label>Новый email:</label>
     <input type="email" name="new_email" value="<?php echo htmlspecialchars($account['email'] ?? ''); ?>">

--- a/admin_forum_sections.php
+++ b/admin_forum_sections.php
@@ -84,7 +84,7 @@ include 'templates/header.php';
 <?php endforeach; ?>
 </ul>
 <h3>Добавить раздел</h3>
-<form action="admin_forum_sections.php" method="post">
+<form class="styled-form" action="admin_forum_sections.php" method="post">
     <input type="hidden" name="action" value="add">
     <label>Название:</label>
     <input type="text" name="title">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -340,3 +340,44 @@ table.ranking th {
     display: block;
     margin: 10px auto 0 auto;
 }
+
+/* Generic form styling used across the site */
+.styled-form {
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid #ffcc00;
+    border-radius: 8px;
+    padding: 15px;
+    max-width: 600px;
+    margin: 20px auto;
+}
+
+.styled-form label {
+    display: block;
+    margin-bottom: 6px;
+    color: #ffcc00;
+    font-weight: bold;
+}
+
+.styled-form input[type="text"],
+.styled-form input[type="password"],
+.styled-form input[type="email"],
+.styled-form textarea {
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 10px;
+    border: 1px solid #ffcc00;
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+}
+
+.styled-form input[type="submit"] {
+    background: #ffcc00;
+    color: #000;
+    border: none;
+    padding: 10px;
+    width: 100%;
+    border-radius: 5px;
+    cursor: pointer;
+    font-weight: bold;
+}

--- a/contact.php
+++ b/contact.php
@@ -2,7 +2,7 @@
 include 'templates/header.php';
 ?>
 <h2>Форма обратной связи</h2>
-<form action="#" method="post">
+<form class="styled-form" action="#" method="post">
     <label for="contact_name">Имя:</label>
     <input type="text" id="contact_name" name="contact_name">
     <label for="contact_email">Email:</label>

--- a/edit_news.php
+++ b/edit_news.php
@@ -38,7 +38,7 @@ include 'templates/header.php';
 <?php if ($success): ?>
     <div class="success"><?php echo htmlspecialchars($success); ?></div>
 <?php endif; ?>
-<form action="edit_news.php" method="post" onsubmit="document.getElementById('content').value=document.getElementById('editor').innerHTML;">
+<form class="styled-form" action="edit_news.php" method="post" onsubmit="document.getElementById('content').value=document.getElementById('editor').innerHTML;">
     <div id="toolbar">
         <button type="button" data-cmd="bold"><b>B</b></button>
         <button type="button" data-cmd="italic"><i>I</i></button>

--- a/forum_new_topic.php
+++ b/forum_new_topic.php
@@ -68,7 +68,7 @@ include 'templates/header.php';
     <?php endforeach; ?>
 </div>
 <?php endif; ?>
-<form action="forum_new_topic.php?id=<?php echo $sectionId; ?>" method="post">
+<form class="styled-form" action="forum_new_topic.php?id=<?php echo $sectionId; ?>" method="post">
     <label>Заголовок:</label>
     <input type="text" name="title">
     <label>Сообщение:</label>

--- a/forum_topic.php
+++ b/forum_topic.php
@@ -58,7 +58,7 @@ include 'templates/header.php';
     <?php endforeach; ?>
 </div>
 <?php endif; ?>
-<form action="forum_topic.php?section=<?php echo $sectionId; ?>&topic=<?php echo $topicId; ?>" method="post">
+<form class="styled-form" action="forum_topic.php?section=<?php echo $sectionId; ?>&topic=<?php echo $topicId; ?>" method="post">
     <textarea name="content" rows="4" cols="60"></textarea>
     <input type="submit" value="Отправить">
 </form>

--- a/login.php
+++ b/login.php
@@ -52,7 +52,7 @@ include 'templates/header.php';
     </div>
 <?php endif; ?>
 
-<form action="login.php" method="post">
+<form class="styled-form" action="login.php" method="post">
     <label for="login_username">Имя:</label>
     <input type="text" id="login_username" name="login_username">
     <label for="login_password">Пароль:</label>


### PR DESCRIPTION
## Summary
- add generic `.styled-form` rules to `style.css`
- apply `.styled-form` class to contact, login, account, forum and admin pages
- style admin news editor and forum section forms

## Testing
- `php -l account.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685b156af060832ba4994925482082db