### PR TITLE
Enable console logging for DB connections

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,6 +10,7 @@ function logDbConnection($db, $host, $user, $status, $message = '') {
     }
     $entry .= PHP_EOL;
     @file_put_contents($file, $entry, FILE_APPEND);
+    error_log($entry);
 }
 
 function selectDB($db) {


### PR DESCRIPTION
## Summary
- log database connection entries to the PHP console via `error_log`

## Testing
- `php -l includes/functions.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c638941d4832b9348e7e4bb4f66ab