### PR TITLE
Fix registration for empty database

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -189,7 +189,8 @@ function createAccount($username, $password, $email) {
         if ($config['max_compatibility_mode']) {
             $query = doQuery('SELECT id FROM ' . TABLE_ACCOUNT_LOGIN . ' WHERE name = ?', DATABASE_ACCOUNT, [$username]);
         } else {
-            $query = doQuery('SELECT (MAX(act_id) + 1) AS id FROM ' . TABLE_ACCOUNT, DATABASE_GAME);
+            // `MAX(act_id) + 1` returns NULL on empty tables, so use ISNULL to ensure we start at 1
+            $query = doQuery('SELECT ISNULL(MAX(act_id), 0) + 1 AS id FROM ' . TABLE_ACCOUNT, DATABASE_GAME);
         }
 
         if ($query === false) {


### PR DESCRIPTION
## Summary
- avoid `NULL` account IDs when the `account` table is empty

## Testing
- `php -l includes/functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685c7c01217c832b95c59d3b7bb2c7f9