### PR TITLE
Add donation balance link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PKO Site
+
+This repository contains a simple PHP based website for a private server. It uses Microsoft SQL Server for account and game databases as configured in `includes/config.php`.
+
+## Donation Currency
+
+Donation currency is stored in the `account_login` table of the account database. The value is kept in the `donat` column. New accounts created via the site automatically set this field to `0`.
+
+

--- a/account.php
+++ b/account.php
@@ -75,7 +75,7 @@ include 'templates/header.php';
         <li><?php echo htmlspecialchars($char); ?></li>
     <?php endforeach; ?>
 </ul>
-<p>Донат валюта: 0</p>
+<p>Донат валюта: <?php echo htmlspecialchars($account['donat'] ?? 0); ?></p>
 <button>Пополнить баланс</button>
 
 <h3>Смена пароля</h3>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -169,6 +169,7 @@ function createAccount($username, $password, $email) {
         ['field' => 'total_live_time', 'value' => 0, 'type' => 'i'],
         ['field' => 'last_login_mac', 'value' => '', 'type' => 's'],
         ['field' => 'ban', 'value' => 0, 'type' => 'i'],
+        ['field' => 'donat', 'value' => 0, 'type' => 'i'],
         ['field' => 'email', 'value' => $email, 'type' => 's']
     ];
 


### PR DESCRIPTION
## Summary
- display account donation balance
- store `donat` value when creating an account
- document donation currency location

## Testing
- `php -l account.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c86548904832b9f26efb75f49c10c